### PR TITLE
Jump_host also receives the correct user.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 A container that exposes remote ports to your containers via ssh local forwarding.
 
 
+It is also possible to use a jump host:
+
+* Specify the jump host via `JUMP_HOST`
+* (Optional): Specify a jump user via `JUMP_USER`
+
 ## Examples
 
 Suppose we want to expose PORT 8080 and 8081 to the containers in our network.
@@ -30,6 +35,7 @@ services:
       - USER=user
       - HOST=example.org
       - JUMP_HOST=my.jump_host.example.org
+      - JUMP_USER=jump_user
       - PORTS=80:8080,81:8081
     volumes:
       - ~/.ssh/id_rsa:/root/.ssh/id_rsa

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,13 @@
 set -e
 
+if [ -z "$JUMP_USER" ]; then
+  JUMP_USER="$USER"
+fi
+
 if [ -z "$JUMP_HOST" ]; then
   JUMP_HOST="$HOST"
 else
-  JUMP_HOST="-J $USER@$JUMP_HOST $HOST"
+  JUMP_HOST="-J $JUMP_USER@$JUMP_HOST $HOST"
 fi
 
 FORWARDING_CONFIG=""

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 if [ -z "$JUMP_HOST" ]; then
   JUMP_HOST="$HOST"
 else
-  JUMP_HOST="-J $JUMP_HOST $HOST"
+  JUMP_HOST="-J $USER@$JUMP_HOST $HOST"
 fi
 
 FORWARDING_CONFIG=""


### PR DESCRIPTION
Previously, when "jump_hosting", the default ssh user was used. However, the jump host also should take the `USER` env variable into account.